### PR TITLE
Use HTTPS protocol instead of SSH for MMX feeds

### DIFF
--- a/lua/luaxml/Makefile
+++ b/lua/luaxml/Makefile
@@ -76,7 +76,7 @@ PKG_VERSION:=$(PKG_REV)
 PKG_RELEASE:=5426
 
 
-PKG_SOURCE_URL:=ssh://git@github.com/InangoSystems/luaxml.git
+PKG_SOURCE_URL:=https://github.com/InangoSystems/luaxml.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=76ff8a97e86c6833788dabd588721696402f1a86
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz

--- a/mng/mmx-cli/Makefile
+++ b/mng/mmx-cli/Makefile
@@ -73,7 +73,7 @@ PKG_NAME:=mmx-cli
 PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ssh://git@github.com/InangoSystems/mmx-cli.git
+PKG_SOURCE_URL:=https://github.com/InangoSystems/mmx-cli.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=96914c66790dae4c45c69336300ae85820c45e5d
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz

--- a/net/libing-gen-utils/Makefile
+++ b/net/libing-gen-utils/Makefile
@@ -75,7 +75,7 @@ PKG_NAME:=libing-gen-utils
 PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ssh://git@github.com/InangoSystems/libing-gen-utils.git
+PKG_SOURCE_URL:=https://github.com/InangoSystems/libing-gen-utils.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=02c3d37974222f770ad85d1e8d210eaa531ffa2b
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz

--- a/net/libmmx-backapi/Makefile
+++ b/net/libmmx-backapi/Makefile
@@ -74,7 +74,7 @@ PKG_NAME:=libmmx-backapi
 PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ssh://git@github.com/InangoSystems/libmmx-backapi.git
+PKG_SOURCE_URL:=https://github.com/InangoSystems/libmmx-backapi.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=f155b2cf39219b2d2505d65ed8cc02e1453c8f44
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz

--- a/net/libmmx-frontapi/Makefile
+++ b/net/libmmx-frontapi/Makefile
@@ -75,7 +75,7 @@ PKG_NAME:=libmmx-frontapi
 PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ssh://git@github.com/InangoSystems/libmmx-frontapi.git
+PKG_SOURCE_URL:=https://github.com/InangoSystems/libmmx-frontapi.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=41dcad7bd830b53695e96d036d66644ce6304235
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz

--- a/net/mmx-ep/Makefile
+++ b/net/mmx-ep/Makefile
@@ -75,7 +75,7 @@ PKG_NAME:=mmx-ep
 PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ssh://git@github.com/InangoSystems/mmx-ep.git
+PKG_SOURCE_URL:=https://github.com/InangoSystems/mmx-ep.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=033b05fef89c1ea63ba3f87efcf90b601ee74560
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz

--- a/net/prplmesh-be/Makefile
+++ b/net/prplmesh-be/Makefile
@@ -74,7 +74,7 @@ PKG_NAME:=prplmesh-be
 PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ssh://git@github.com/InangoSystems/prplmesh-be.git
+PKG_SOURCE_URL:=https://github.com/InangoSystems/prplmesh-be.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=58ae217fd3d13ac3af7308085c2b460234a8eb28
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz


### PR DESCRIPTION
To be able to build MMX on CI it'd better to use https proto
instead of ssh in packages URLs

Replace 'ssh://git@' -> 'https://'
