### PR TITLE
inango-prplmesh-be: fix package build fail on db_reformat Lua scripts absence

### DIFF
--- a/customers/inango-prplmesh-en/Makefile
+++ b/customers/inango-prplmesh-en/Makefile
@@ -218,8 +218,10 @@ define Package/inango-prplmesh-en/install
 	$(INSTALL_DIR) $(1)/$(MMX_DEFAULTS_DB_PATH)
 	$(INSTALL_BIN) ./mmxdbfiles/db/mmx_meta_db $(1)/$(MMX_DEFAULTS_DB_PATH)/mmx_meta_db
 	$(INSTALL_BIN) ./mmxdbfiles/db/mmx_main_db $(1)/$(MMX_DEFAULTS_DB_PATH)/mmx_main_db
-	$(INSTALL_DIR) $(1)/$(MMX_DEFAULTS_DB_REFOFMAT_PATH)
-	$(INSTALL_BIN) ./mmxdbfiles/db_reformat/*.lua $(1)/$(MMX_DEFAULTS_DB_REFOFMAT_PATH)/
+	if ls ./mmxdbfiles/db_reformat/*.lua; then \
+	        $(INSTALL_DIR) $(1)/$(MMX_DEFAULTS_DB_REFOFMAT_PATH); \
+	        $(INSTALL_BIN) ./mmxdbfiles/db_reformat/*.lua $(1)/$(MMX_DEFAULTS_DB_REFOFMAT_PATH)/; \
+	fi
 
 	# WEB files processing
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/mmx


### PR DESCRIPTION
DB reformat scripts are needed only for MMX DB migrations but
they are not needed for MMX v.2.0.1.1 and outdated scritps has
been removed

But "inango-prplmesh-en" Makefile fails on try to install deleted
Lua migration scripts

Make that installation script conditionable - only when almost one
DB reformat script is present

Closes #17 