### PR TITLE
MMX WEB: prpl web layout for "No password set!" message

### DIFF
--- a/customers/inango-prplmesh-en/showfiles/cascade.css
+++ b/customers/inango-prplmesh-en/showfiles/cascade.css
@@ -35,8 +35,11 @@ div#maincontent ul {
 }
 
 .warning {
-	color: red !important;
-	font-weight: bold;
+	color: #441042;
+	background-color: #cebfd8;
+	padding: 0.5em;
+	padding-left: 15px;
+	font-size: 12px;
 }
 
 .clear {


### PR DESCRIPTION
There are next warning message in the top of each MMX WebUI page if root
user password is not set
```
    No password set!
    There is no password set on this router. Please configure a root  password to protect the web interface and enable SSH.
```
That message use default colors and should be adopted for prpl colors
and logos

Set prpl colors for "warning" CSS class

## Screenshots

### Before

![feed-mmx-pr25-before](https://user-images.githubusercontent.com/2241945/108337390-e141a000-71f6-11eb-896b-59026096ce80.png)

### After

![feed-mmx-pr25-after](https://user-images.githubusercontent.com/2241945/108338976-ac364d00-71f8-11eb-8e5a-767f28e93aa2.png)
![feed-mmx-pr25-after-2](https://user-images.githubusercontent.com/2241945/108339100-d425b080-71f8-11eb-9022-2382472cfbef.png)




Closes #25 