### PR TITLE
MMX WEB: LuCI does not load if user-be is present

### DIFF
--- a/mng/mmx-web/src/mmx-controller.lua
+++ b/mng/mmx-web/src/mmx-controller.lua
@@ -82,7 +82,7 @@ module("luci.controller.mmx", package.seeall)
 function index()
     require("luci.mmx.mmx_web_routines")
     -- If mmx-user-be package is disabled then we LuCi will auth all system users with "Admin" rights
-    local st, userbe = pcall(require, "mmx.userbe_utils")
+    local st, _ = pcall(require, "mmx.userbe_utils")
     local getPermissionByUsername = st and userbe.utils.getPermissionByUsername or function() return "Admin" end
 
     local has_sauth, sauth = pcall(require, "luci.sauth")
@@ -129,7 +129,7 @@ function render_mmx_page()
     require("luci.dispatcher")
     require("luci.mmx.mmx_web_routines")
     -- If mmx-user-be package is disabled then we LuCi will auth all system users with "Admin" rights
-    local st, userbe = pcall(require, "mmx.userbe_utils")
+    local st, _ = pcall(require, "mmx.userbe_utils")
     local getPermissionByUsername = st and userbe.utils.getPermissionByUsername or function() return "Admin" end
 
     engine = MMXWebEngine.create()


### PR DESCRIPTION
If image with MMX contains "user-be" package then LuCI cannot be opened
because of error
```
/usr/lib/lua/luci/controller/mmx.lua:86: attempt to index local 'userbe'
(a boolean value)
stack traceback:
    /usr/lib/lua/luci/controller/mmx.lua:86: in function 'v'
    /usr/lib/lua/luci/dispatcher.lua:695: in function 'createtree'
    /usr/lib/lua/luci/dispatcher.lua:347: in function 'dispatch'
    /usr/lib/lua/luci/dispatcher.lua:208: in function
    </usr/lib/lua/luci/dispatcher.lua:207>
```
Reason was next: "userbe" has been loaded previously so 'require'
returned "true" instead of module table

Closes #33 