### PR TITLE
mmx-web: Fix patching dispatcher.lua

### DIFF
--- a/mng/mmx-web/Makefile
+++ b/mng/mmx-web/Makefile
@@ -218,11 +218,6 @@ if [ -z "$${IPKG_INSTROOT}" ]; then
 	if [ -e /usr/lib/lua/luci/model/network.lua -a -e /usr/lib/lua/mmx/mmx-model-network.lua ]; then
 		cp /usr/lib/lua/mmx/mmx-model-network.lua /usr/lib/lua/luci/model/network.lua
 	fi
-
-	# apply patch to use action type "call" in Luci
-	if [ -e /usr/lib/lua/luci/dispatcher.lua -a -e /usr/lib/lua/mmx/dispatcher.lua ]; then
-		cp /usr/lib/lua/mmx/dispatcher.lua /usr/lib/lua/luci/dispatcher.lua
-	fi
 fi
 exit 0
 endef

--- a/mng/mmx-web/files/etc/uci-defaults/mmx-web.init
+++ b/mng/mmx-web/files/etc/uci-defaults/mmx-web.init
@@ -77,6 +77,11 @@ if [ -e /usr/lib/lua/luci/model/network.lua -a -e /usr/lib/lua/mmx/mmx-model-net
     cp /usr/lib/lua/mmx/mmx-model-network.lua /usr/lib/lua/luci/model/network.lua
 fi
 
+# apply patch to use action type "call" in Luci
+if [ -e /usr/lib/lua/luci/dispatcher.lua -a -e /usr/lib/lua/mmx/dispatcher.lua ]; then
+    cp /usr/lib/lua/mmx/dispatcher.lua /usr/lib/lua/luci/dispatcher.lua
+fi
+
 # disable keepalive in uhttpd server
 uci set uhttpd.main.http_keepalive='0'
 uci commit


### PR DESCRIPTION
After couple of checks postinstall script for patching file does not work. Decided to use uci-defaults for patching filem tested on the RAX-40 - works.

Signed-off-by: Vladyslav Tupikin <v.tupikin@inango-systems.com>