### PR TITLE
mmx-web: visually add buttons "Update, Refresh, Add, Delete" for tablegroup view

### DIFF
--- a/customers/inango-prplmesh-en/showfiles/cascade.css
+++ b/customers/inango-prplmesh-en/showfiles/cascade.css
@@ -369,7 +369,6 @@ input.cbi-button-apply {
 	background-color: white;
 	padding-left: 17px;
 	padding-right: 1px;
-	width: 10em;
 }
 
 .cbi-button {
@@ -381,6 +380,7 @@ input.cbi-button-apply {
 	border-radius: 2px;
 	font-size: 14px;
 	border: none;
+	width: 6em;
 }
 
 .cbi-button:hover, .cbi-button:active {
@@ -793,6 +793,10 @@ li.mmx-tab a:hover {
 	margin: 60px 10px 0px;
 }
 
+.mmx-section-top-actions {
+    padding-top: 2em;
+}
+
 .mmx-section-actions {
 	margin-top: 20px;
 }
@@ -939,6 +943,33 @@ a.mmx-revert-row {
 
 .mmx-tablegroup-edit {
 	padding: 8px 9px !important;
+	background-color: inherit !important;
+}
+
+/* pencil sign on edit button above */
+.fa-pencil-alt {
+        color: #72166b;
+}
+
+/* delete button with trash basket sigh */
+.mmx-tablegroup-delete {
+	padding: 8px 9px !important;
+	background-color: inherit !important;
+}
+
+/* busket sign on delete button above */
+.fa-trash-alt {
+    color: #72166b;
+}
+
+.mmx-tablegroup-add {
+	padding: 8px 9px !important;
+	background-color: inherit !important;
+}
+
+/* plus sign on add button above */
+.fa-plus-circle {
+    color: #441042;
 }
 
 a.mmx-tablegroup-revert {

--- a/mng/mmx-web/files/view-mmx-tablegroup.htm
+++ b/mng/mmx-web/files/view-mmx-tablegroup.htm
@@ -90,6 +90,9 @@ for rowIdx, row in ipairs(data) do
     <input class="cbi-button cbi-button-apply mmx-tablegroup-apply" style="display: none;" id="apply-<%=sectIdx%>::<%=section["mmgModObjName"]%>" data-mmx-instance="<%=sectionIndex%>::<%=row["path"]%>" type="submit" value="Apply">
     <button class="cbi-button cbi-button-apply mmx-tablegroup-edit" id="edit-<%=sectionIndex%>::<%=section["mmgModObjName"]%>" data-mmx-instance="<%=sectionIndex%>::<%=row["path"]%>"><i class="fas fa-pencil-alt"></i></button>
     <a href="javascript:void(0)" class="mmx-tablegroup-revert" style="display: none;" data-mmx-instance="<%=sectionIndex%>::<%=row["path"]%>"><i class="fas fa-times-circle"></i></a>
+    <% if sectionPermissions['delete'] then %>
+        <button class="cbi-button cbi-button-delete mmx-tablegroup-delete" id="delete-<%=sectionIndex%>::<%=section["mmgModObjName"]%>" type="submit" data-mmx-instance="<%=sectionIndex%>::<%=row["path"]%>"><i class="fas fa-trash-alt"></i></button>
+    <% end %>
     </div>
 <% end %>
 </div>

--- a/mng/mmx-web/files/view-mmx.htm
+++ b/mng/mmx-web/files/view-mmx.htm
@@ -128,12 +128,18 @@ if sections then
 %>
 <div class="cbi-map">
     <fieldset class="cbi-section mmx-section" style="margin-top: 1em; margin-bottom: 1em; padding: 2em 1em">
+        <% local sectionPermissions = engine:getSectionPermissions(section, userPermission, currentGroup["userWritePerm"]) %>
         <legend>
             <%=section["sectionHeader"]%>
             <% if section["help"] then %>
                 <span class="fas fa-question-circle mmx-tooltip" title="<%=section["help"]%>" />
             <% end %>
         </legend>
+        <% if section['lookType'] == 'tablegroup' then %>
+            <% if sectionPermissions['create'] then %>
+                <div class="mmx-section-top-actions"><button class="cbi-button cbi-button-add mmx-tablegroup-add" id="create-<%=sectionIndex%>::<%=section["mmgModObjName"]%>" type="submit"><i class="fas fa-plus-circle"></i></button></div>
+            <% end %>
+        <% end %>
         <% local sectionData = {} %>
         <% if not engine:checkIsWriteOnly(section) then
             local indirectParams = engine:getIndirectParams(section)
@@ -144,9 +150,7 @@ if sections then
             end
         end %>
         <%=engine:renderHelper(section, sectIdx, sectionData, currentGroup, userPermission)%>
-    <% if section['lookType'] ~= 'tablegroup' then %>
     <div class="mmx-section-actions">
-        <% local sectionPermissions = engine:getSectionPermissions(section, userPermission, currentGroup["userWritePerm"]) %>
         <% if sectionPermissions["update"] then %>
             <input class="cbi-button cbi-button-refresh mmx-section-update" id="update-<%=section["mmgModObjName"]%>" type="submit" title="Update the management object information" value="Update">
         <% end %>
@@ -160,7 +164,6 @@ if sections then
             <input class="cbi-button cbi-button-save mmx-section-save" id="save-<%=sectIdx%>::<%=section["mmgModObjName"]%>" type="submit" value="Apply&amp;Save">
         <% end %>
     </div>
-    <% end %>
     </fieldset>
 </div>
 <%


### PR DESCRIPTION
For writable objects we need ability to add/delete them from MMX WebUI
But "tablegroup" view has no such abilities

Visually (no click handlers yet) add buttons "Update" and "Refresh"
under table with object
  and button "Delete" on right on "Edit" button
  and button "Add" under object section legend title

Closes #11