### PR TITLE
mmx-ep: Increase default value `EP_MAX_METHOD_STR_LEN`

### DIFF
--- a/net/mmx-ep/Config.in
+++ b/net/mmx-ep/Config.in
@@ -130,7 +130,7 @@ config EP_MAX_METHOD_STR_LEN
         depends on PACKAGE_mmx-ep
         int
         prompt "Max method string lenght"
-        default 256
+        default 512
         help
                 Max method string lenght
 


### PR DESCRIPTION
Need to increase default value for `EP_MAX_METHOD_STR_LEN` because some of methods from prplMesh data model contain string larger than 256 characters.

#45 

Signed-off-by: Vladyslav Tupikin <v.tupikin@inango-systems.com>